### PR TITLE
Add apt-get upgrade to fix S360 security vulnerabilities

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -15,6 +15,7 @@ function install_packages(){
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --yes --dearmor -o /etc/apt/keyrings/docker.gpg
     echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu jammy stable" > /etc/apt/sources.list.d/docker.list
     apt-get -o DPkg::Lock::Timeout=600 update
+    apt-get -o DPkg::Lock::Timeout=600 upgrade -y
     apt-get -o DPkg::Lock::Timeout=600 install -y docker-ce docker-ce-cli containerd.io
     apt-get -o DPkg::Lock::Timeout=600 install -y make python3-pip
 }


### PR DESCRIPTION
## Problem

S360 detected outdated packages on VMSS `sonictest2204a` instances (e.g., `libnss3` — USN-8071-1, VulnId 6032068). The `init.sh` custom script runs `apt-get update` but never `apt-get upgrade`, so security patches published after the base image are not applied.

## Fix

Add `apt-get -o DPkg::Lock::Timeout=600 upgrade -y` after `apt-get update` in the `install_packages()` function. This ensures all available security patches are applied at instance provisioning time.

- Uses the same `DPkg::Lock::Timeout=600` as existing apt calls in the script
- Placed before package installs so upgrades are applied first
- The retry loop (3 attempts) already covers this new call

## Impact

Every new VMSS instance will run a full package upgrade during provisioning. This may add 1-3 minutes to instance startup time but ensures compliance with S360 requirements.