### PR TITLE
[ci] add sonic-stp and sonic-platform-vpp to the auto cherry-pick workflow

### DIFF
--- a/azure-pipelines-wrapper/auto_cherrypick.js
+++ b/azure-pipelines-wrapper/auto_cherrypick.js
@@ -3,7 +3,7 @@ const akv = require('./keyvault');
 const repos = ["sonic-net/sonic-utilities", "sonic-net/sonic-swss", "sonic-net/sonic-sairedis", "sonic-net/sonic-swss-common", "sonic-net/sonic-dbsyncd", "sonic-net/sonic-gnmi", "sonic-net/sonic-host-services",
               "sonic-net/sonic-linkmgrd", "sonic-net/sonic-linux-kernel", "sonic-net/sonic-mgmt-common", "sonic-net/sonic-mgmt-framework", "sonic-net/sonic-platform-common", "sonic-net/sonic-platform-daemons",
               "sonic-net/sonic-py-swsssdk", "sonic-net/sonic-restapi", "sonic-net/sonic-snmpagent", "sonic-net/sonic-wpa-supplicant", "sonic-net/sonic-buildimage", "sonic-net/sonic-ztp", "sonic-net/sonic-dhcp-relay",
-              "sonic-net/sonic-mgmt", "sonic-net/sonic-dhcpmon", "sonic-net/sonic-dash-api", "sonic-net/sonic-dash-ha", "sonic-net/sonic-bmp"];
+              "sonic-net/sonic-mgmt", "sonic-net/sonic-dhcpmon", "sonic-net/sonic-dash-api", "sonic-net/sonic-dash-ha", "sonic-net/sonic-bmp", "sonic-net/sonic-stp", "sonic-net/sonic-platform-vpp"];
 
 function init(app) {
     app.log.info("[ AUTO CHERRY PICK ] Init auto cherry pick");


### PR DESCRIPTION
Add new repos to auto cherry-pick: Added sonic-net/sonic-stp and sonic-net/sonic-platform-vpp to the auto cherry-pick workflow