### PR TITLE
[agent provisioning] migrate from python3-pip to uv to address S360 vulnerability

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -27,6 +27,9 @@ fi
 
 apt-get install -y make python3-pip
 
+# install uv (Python package manager)
+curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh
+
 # install br_netfilter kernel module
 modprobe br_netfilter
 # set sysctl bridge parameters for testbed
@@ -42,8 +45,6 @@ sysctl -w net.core.rmem_default=509430500
 
 # enable nat
 iptables -t nat -A POSTROUTING -s 10.250.0.0/24 -o eth0 -j MASQUERADE
-
-# pip3 install docker==6.1.0 requests==2.31.0
 
 # create two partition on the 1T data disk
 # first partition for azure pipeline agent


### PR DESCRIPTION
## Summary
Switches provisioning from `pip3` to `uv` for installing the Python build dependencies, so we no longer rely on `pip3 install` at provision time.

## Why
- `python3-pip` triggers S360 security alerts and needs to be upgrade to a version that is only available in ubuntu pro.
- `uv` ships its own resolver/installer, so packages can be installed without pip.

## Changes (init.sh)
- Install `uv` system-wide into `/usr/local/bin`.

## Follow-up
- Drop `python3-pip` from the apt install list once no pipeline depends on it.