### PR TITLE
[ci] Prune stale workspace tmp.* dirs to cap /data disk usage

### DIFF
--- a/azure-pipelines-wrapper/env_init_daemon.sh
+++ b/azure-pipelines-wrapper/env_init_daemon.sh
@@ -1,5 +1,21 @@
 #!/bin/bash -ex
 
+# Cap workspace disk usage. Every PR event copies a per-run tmp.* dir into
+# /data/workspace/<folder>-<repo>/ (see bash_action.sh) and nothing ever removed
+# them, so /data filled up. Prune old per-run dirs on every daemon tick (runs as
+# root, ~every 30 min from env_init.js). Retention is tunable: keep 60 days
+# normally, drop to 20 days when /data is above 70% full.
+# /data and /home are remote mounts (Azure Files NFS / SMB): each find is wrapped
+# in `timeout` so a stalled mount can't hang the sweep, and uses
+# -ignore_readdir_race to tolerate tmp.* being created/removed concurrently.
+for ws in /data/workspace /home/site/wwwroot/workspace; do
+    [ -d "$ws" ] && timeout 900 find "$ws" -maxdepth 2 -ignore_readdir_race -name 'tmp.*' -type d -mtime +60 -exec rm -rf {} + || true
+done
+data_used=$(df --output=pcent /data 2>/dev/null | tr -dc '0-9')
+if [ -n "$data_used" ] && [ "$data_used" -gt 70 ]; then
+    timeout 900 find /data/workspace -maxdepth 2 -ignore_readdir_race -name 'tmp.*' -type d -mtime +20 -exec rm -rf {} + || true
+fi
+
 if (( $(stat --format %s /home/env_init_daemon.stderr)/1000/1000/1000 > 2 )); then
     cd /home
     mv env_init_daemon.stderr env_init_daemon.stderr.back


### PR DESCRIPTION
## Problem
`azure-pipelines-wrapper` runs `bash_action.sh` on every PR event and copies each run's `tmp.*` dir into `/data/workspace/<folder>-<repo>/`, but nothing ever removed them. With no size cap or retention, `/data` (a 1 TB Azure Files mount) filled up to 842 GB / 83%.

The daemon's old cleanup was dead code (sat after an early `exit 0`) and only ever targeted `/home`, never `/data`.

## Fix
Add a retention sweep at the top of `env_init_daemon.sh` (runs ~every 30 min as root, before the early exit):
- Delete `tmp.*` dirs older than **60 days** on both `/data` and `/home` workspaces.
- Drop to **20 days** when `/data` is over **70%** full (safety valve).
- Each `find` is wrapped in `timeout 900` and uses `-ignore_readdir_race`, because `/data` and `/home` are remote mounts (Azure Files NFS / SMB): a stalled mount can't hang the sweep, and concurrent `tmp.*` creation/removal won't error out.

## Sizing (measured on the box)
~26k `tmp.*` dirs averaging ~33 MB (~7 GB/day). ~49% fall within 60 days, so the 60-day steady state is ~410 GB (~41% of 1 TB), leaving ample headroom; the >70% guard trims to 20 days (~140 GB) only in a rare burst.

## Testing
Validated in an isolated sandbox with 0-/30-/61-day dirs: the 60-day sweep deletes only the 61-day dir; the >70% guard additionally deletes the 30-day dir; below 70% nothing is removed; `df --output=pcent` parses correctly. 10/10 assertions pass.