### PR TITLE
Pass ACTION_SENDER to auto cherry-pick script

### DIFF
--- a/azure-pipelines-wrapper/auto_cherrypick.js
+++ b/azure-pipelines-wrapper/auto_cherrypick.js
@@ -50,6 +50,7 @@ function init(app) {
         param.push(`PR_LABELS="${labels.join(',')}"`)
         if (payload.action == 'labeled') {
             param.push(`ACTION_LABEL="${payload.label.name}"`)
+            param.push(`ACTION_SENDER="${payload.sender.login}"`)
         }
 
         app.log.info(["[ AUTO CHERRY PICK ]"].concat(param).join(" "))


### PR DESCRIPTION
Push `ACTION_SENDER` (from `payload.sender.login`) to the auto cherry-pick script for the `labeled` action.
By passing this variable, the `auto-cherry-pick.sh` (in sonic-pipelines) is able to verify if a label is added by a release-manager team member