### PR TITLE
replace ADO PATs with managed identity to address security alters

### DIFF
--- a/azure-pipelines-wrapper/adoauth.js
+++ b/azure-pipelines-wrapper/adoauth.js
@@ -1,0 +1,30 @@
+const { ManagedIdentityCredential, DefaultAzureCredential } = require("@azure/identity");
+require('dotenv').config();
+
+// Well-known Azure DevOps resource (application) ID. A token issued for this
+// scope is accepted by the Azure DevOps REST APIs and git endpoints of any
+// organization backed by the same Entra tenant as the managed identity.
+const ADO_SCOPE = "499b84ac-1321-427f-aa17-267ca6975798/.default";
+
+// Use a dedicated credential for Azure DevOps so Key Vault's DefaultAzureCredential
+// (in keyvault.js) is left untouched. When ADO_MI_CLIENT_ID is set (App Service with
+// a user-assigned managed identity), request tokens as that specific identity;
+// otherwise fall back to DefaultAzureCredential (e.g. local dev via `az login`).
+const credential = process.env.ADO_MI_CLIENT_ID
+    ? new ManagedIdentityCredential({ clientId: process.env.ADO_MI_CLIENT_ID })
+    : new DefaultAzureCredential();
+
+let cachedToken = null;
+
+async function getAdoAadToken() {
+    // Reuse the cached token until ~5 minutes before it expires.
+    if (cachedToken && cachedToken.expiresOnTimestamp - Date.now() > 5 * 60 * 1000) {
+        return cachedToken.token;
+    }
+    cachedToken = await credential.getToken(ADO_SCOPE);
+    return cachedToken.token;
+}
+
+module.exports = Object.freeze({
+    getAdoAadToken: getAdoAadToken,
+});

--- a/azure-pipelines-wrapper/azp.js
+++ b/azure-pipelines-wrapper/azp.js
@@ -2,12 +2,13 @@ const azdev=require("azure-devops-node-api");
 const azbuild=require("azure-devops-node-api/BuildApi");
 require('dotenv').config();
 const akv = require('./keyvault.js');
+const adoauth = require('./adoauth.js');
 const detail_url_prefix = 'https://dev.azure.com/';
 
 async function getconnection(org){
     var orgUrl = "https://dev.azure.com/" + org;
-    var token = await akv.getAzDevOpsToken();
-    var authHandler = azdev.getPersonalAccessTokenHandler(token);
+    var token = await adoauth.getAdoAadToken();
+    var authHandler = azdev.getBearerHandler(token);
     var connection = new azdev.WebApi(orgUrl, authHandler);
     return connection;
 }

--- a/azure-pipelines-wrapper/conflict_detect.js
+++ b/azure-pipelines-wrapper/conflict_detect.js
@@ -4,6 +4,7 @@ const util = require('util');
 const { setTimeout } = require('timers/promises');
 const eventhub = require('./eventhub');
 const akv = require('./keyvault');
+const adoauth = require('./adoauth');
 const { EmailClient } = require("@azure/communication-email");
 const InProgress = 'in_progress'
 const MsConflict = 'ms_conflict'
@@ -221,7 +222,7 @@ function init(app) {
 
         var url, number, commit, base_branch, pr_owner, check_suite
         var script_branch = await akv.getSecretFromCache("CONFLICT_SCRIPT_BRANCH")
-        var msazure_token = await akv.getSecretFromCache("MSAZURE_TOKEN")
+        var msazure_token = await adoauth.getAdoAadToken()
 
         var param = Array()
         param.push(`FOLDER=conflict`)
@@ -278,7 +279,7 @@ function init(app) {
         param.push(`UUID=${uuid}`)
         param.push(`REPO=${repo}`)
         param.push(`GH_TOKEN=${gh_token}`)
-        param.push(`MSAZURE_TOKEN=${msazure_token}`)
+        param.push(`MSAZURE_TOKEN=x-access-token:${msazure_token}`)
         param.push(`SCRIPT_URL=https://mssonicbld:${gh_token}@raw.githubusercontent.com/Azure/sonic-pipelines-internal/${script_branch}/azure-pipelines/ms_conflict_detect.sh`)
         param.push(`PR_NUMBER=${number}`)
         param.push(`PR_URL=${url}`)

--- a/azure-pipelines-wrapper/issue_comment.js
+++ b/azure-pipelines-wrapper/issue_comment.js
@@ -5,6 +5,7 @@ const { execSync } = require('child_process');
 require('dotenv').config();
 const azp = require('./azp');
 const akv = require('./keyvault');
+const adoauth = require('./adoauth');
 const check_run = require('./check_run');
 const { retry } = require("@azure/core-amqp");
 
@@ -143,10 +144,10 @@ async function retryFailedBuilds(context) {
         return;
     }
 
-    var az_token = await akv.getAzDevOpsToken();
+    var az_token = await adoauth.getAdoAadToken();
 
     var timelineUrl = `https://dev.azure.com/${latestBuild.org}/${latestBuild.projectId}/_apis/build/builds/${latestBuild.buildId}/timeline?api-version=7.1`;
-    var timelineCmd = `curl --silent --show-error --request GET --url "${timelineUrl}" --user ":${az_token}" --header "Content-Type: application/json"`;
+    var timelineCmd = `curl --silent --show-error --request GET --url "${timelineUrl}" --header "Authorization: Bearer ${az_token}" --header "Content-Type: application/json"`;
     var timelineOutput = execSync(timelineCmd, { encoding: 'utf-8' });
     var timeline;
     try {
@@ -224,7 +225,7 @@ async function retryFailedBuilds(context) {
     for (var stage of failedStages) {
         try {
             var url = `https://dev.azure.com/${latestBuild.org}/${latestBuild.projectId}/_apis/build/builds/${latestBuild.buildId}/stages/${stage.identifier}?api-version=7.1`;
-            var cmd = `curl --silent --show-error --request PATCH --url "${url}" --user ":${az_token}" --header "Content-Type: application/json" --data '${data}'`;
+            var cmd = `curl --silent --show-error --request PATCH --url "${url}" --header "Authorization: Bearer ${az_token}" --header "Content-Type: application/json" --data '${data}'`;
             var output = execSync(cmd, { encoding: 'utf-8' });
             console.log(`Retried stage '${stage.identifier}' in build ${latestBuild.buildId}: ${output}`);
             summaryLines.push(`\n\n✅Stage **${stage.identifier}**:`);

--- a/azure-pipelines-wrapper/keyvault.js
+++ b/azure-pipelines-wrapper/keyvault.js
@@ -38,10 +38,6 @@ async function getAppWebhookSecret()
 {
     return await getSecretFromCache("WEBHOOK_SECRET");
 }
-async function getAzDevOpsToken()
-{
-    return await getSecretFromCache("MSSONIC_TOKEN");
-}
 async function getGithubToken()
 {
     return await getSecretFromCache("GITHUB_TOKEN");
@@ -55,7 +51,6 @@ async function getEventhubConnectionstring()
 module.exports = Object.freeze({
     getAppPrivateKey: getAppPrivateKey,
     getAppWebhookSecret: getAppWebhookSecret,
-    getAzDevOpsToken: getAzDevOpsToken,
     getSecretFromCache: getSecretFromCache,
     getGithubToken: getGithubToken,
     getEventhubConnectionstring: getEventhubConnectionstring,


### PR DESCRIPTION
ADO PATs (`MSSONIC_TOKEN` / `MSAZURE_TOKEN`) are not allowed anymore, so this switches the wrapper over to the App Service's managed identity instead. Added a user assigned managed identity to the web app. The managed identity already has access to both the mssonic and msazure orgs, so we can just use a short-lived AAD token per request rather than pulling a long-lived secret from Key Vault.

Main bits:

- Added `adoauth.js` with a small `getAdoAadToken()` helper. It requests a token for the ADO resource scope (`499b84ac-1321-427f-aa17-267ca6975798/.default`) and caches it until ~5 min before expiry. Uses `ManagedIdentityCredential` with `ADO_MI_CLIENT_ID` on App Service, and falls back to `DefaultAzureCredential` for local dev. Kept it separate from the Key Vault credential so `keyvault.js` is untouched.
- `azp.js`: connection now uses `getBearerHandler` with the AAD token instead of the PAT handler.
- `issue_comment.js`: the build timeline/stage-retry curl calls use an `Authorization: Bearer` header now instead of `--user ":<pat>"`.
- `conflict_detect.js`: `MSAZURE_TOKEN` passed to the conflict scripts now comes from the MI token.
- `keyvault.js`: dropped the now-unused `getAzDevOpsToken()`.

Note: the token goes to the shell scripts as `MSAZURE_TOKEN=x-access-token:<token>`. `ms_conflict_detect.sh` uses it as-is in the git remote URL (the `x-access-token:` part is just the basic-auth username), and `azdevops_git_api.sh` strips the prefix for the Bearer header on the REST calls. Paired with Azure/sonic-pipelines-internal#53.

Before merging, `ADO_MI_CLIENT_ID` needs to be set on both the prod slot and the deployment slot (MIs and app settings are per-slot), and the MI needs the usual repo/build permissions in both orgs.

Tested that the MI token comes back 200 against both orgs and git/REST calls auth fine with it.
