### PR TITLE
[agent provisioning] remove python3-pip from apt install list

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -25,7 +25,7 @@ else
     apt-get install -y docker-ce docker-ce-cli containerd.io
 fi
 
-apt-get install -y make python3-pip
+apt-get install -y make
 
 # install uv (Python package manager)
 curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh


### PR DESCRIPTION
Follow-up to #29: now that `uv` installs the Python build dependencies, `python3-pip` is no longer needed here. It also triggers S360 security alerts, so drop it from the apt install list.
